### PR TITLE
Add supplement sync workflow

### DIFF
--- a/.github/workflows/update-supplement-stock-online.yml
+++ b/.github/workflows/update-supplement-stock-online.yml
@@ -1,0 +1,71 @@
+name: update-supplement-stock-online
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync-supplements:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Fetch supplement data
+        id: fetch_supplement_data
+        env:
+          BIOWELL_API_KEY: ${{ secrets.BIOWELL_API_KEY }}
+        run: |
+          curl -H "Authorization: Bearer $BIOWELL_API_KEY" \
+            -o supplement_data.json \
+            https://api.biowell.ai/v1/supplements/all
+
+      - name: Validate supplement data
+        id: validate_data
+        run: |
+          python - <<'PY'
+import json, sys
+required_fields = ["id", "name", "category", "dosage", "unit", "availability"]
+with open('supplement_data.json') as f:
+    data = json.load(f)
+for item in data:
+    for field in required_fields:
+        if field not in item:
+            raise AssertionError(f"Missing {field} in {item}")
+with open('validated_data.json', 'w') as f:
+    json.dump(data, f)
+PY
+
+      - name: Map to online format
+        id: map_to_online_format
+        run: |
+          python - <<'PY'
+import json
+with open('validated_data.json') as f:
+    supplement_inventory = json.load(f)
+mapped_data = []
+for item in supplement_inventory:
+    mapped_data.append({
+        "id": item["id"],
+        "title": item["name"],
+        "category": item["category"],
+        "dose": f"{item['dosage']} {item['unit']}",
+        "in_stock": item["availability"] > 0,
+        "tags": ["science-backed"] + (item.get("tags") or [])
+    })
+with open('supplement_web_payload.json', 'w') as f:
+    json.dump(mapped_data, f)
+PY
+
+      - name: Update frontend store
+        id: update_frontend_store
+        env:
+          FRONTEND_API_KEY: ${{ secrets.FRONTEND_API_KEY }}
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer $FRONTEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            --data @supplement_web_payload.json \
+            https://biowell.ai/api/frontend/supplements/update
+
+      - name: Log completion
+        run: echo "✅ Supplement stock updated to online frontend successfully."


### PR DESCRIPTION
## Summary
- add GH Actions workflow to sync supplement inventory to the frontend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d83be6fdc8328b467db36e59bb396