### PR TITLE
Configure Netlify deployment for biowell.ai

### DIFF
--- a/.github/workflows/update-supplement-stock-online.yml
+++ b/.github/workflows/update-supplement-stock-online.yml
@@ -67,7 +67,7 @@ PY
             -H "Authorization: Bearer $FRONTEND_API_KEY" \
             -H "Content-Type: application/json" \
             --data @supplement_web_payload.json \
-            https://biowell.ai/api/frontend/supplements/update
+            http://biowell.ai/api/frontend/supplements/update
 
       - name: Log completion
         run: echo "✅ Supplement stock updated to online frontend successfully."

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Run `npm run sync:supplements` to fetch the latest inventory from the Biowell AP
 
 This project is built with TypeScript and uses modern ES modules.
 
+## Netlify Deployment
+
+Deployments are configured for Netlify using `netlify.toml`. The production site
+is available at [http://biowell.ai](http://biowell.ai). The `FRONTEND_ENDPOINT`
+environment variable is set automatically during the Netlify build to ensure the
+API updates point to this domain.
+
 ## License
 This project is licensed under the MIT License.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[context.production.environment]
+  FRONTEND_ENDPOINT = "http://biowell.ai/api/frontend/supplements/update"

--- a/src/api/supplementSync.ts
+++ b/src/api/supplementSync.ts
@@ -20,7 +20,7 @@ export interface SupplementWeb {
 }
 
 const BIOWELL_ENDPOINT = process.env.BIOWELL_ENDPOINT || 'https://api.biowell.ai/v1/supplements/all';
-const FRONTEND_ENDPOINT = process.env.FRONTEND_ENDPOINT || 'https://biowell.ai/api/frontend/supplements/update';
+const FRONTEND_ENDPOINT = process.env.FRONTEND_ENDPOINT || 'http://biowell.ai/api/frontend/supplements/update';
 
 export async function fetchSupplementStock(apiKey: string): Promise<SupplementStock[]> {
   const response = await fetch(BIOWELL_ENDPOINT, {


### PR DESCRIPTION
## Summary
- configure Netlify build and environment
- update default frontend URL to use http scheme
- update workflow to post to http://biowell.ai
- document Netlify deployment

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686db0a57ae08328993112543d072e10